### PR TITLE
Restore RegisterForReflection after regression in #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ buildNumber.properties
 # End of https://www.toptal.com/developers/gitignore/api/maven,java,macos,visualstudiocode
 
 .settings
+
+snapshots

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ buildNumber.properties
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,java,macos,visualstudiocode
+
+.settings

--- a/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
+++ b/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
@@ -64,7 +64,7 @@ class QuarkusMpxjProcessor {
           return classes.stream();
         })
         .forEach(classInfo -> {
-          ReflectiveClassBuildItem.Builder b = ReflectiveClassBuildItem.builder(classInfo.name().toString());
+          ReflectiveClassBuildItem.Builder b = ReflectiveClassBuildItem.builder(classInfo.getClass());
           reflectiveClass
               .produce(b.methods().fields().build());
           reflectiveClass

--- a/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
+++ b/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
@@ -1,7 +1,9 @@
 package se.yolean.quarkus.mpxj.deployment;
 
+import java.util.Collection;
 import java.util.List;
 
+import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.IndexView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +58,11 @@ class QuarkusMpxjProcessor {
     IndexView index = combinedIndexBuildItem.getIndex();
 
     packagesToReflect.stream()
-        .flatMap(pack -> index.getClassesInPackage(pack).stream())
+        .flatMap(pack -> {
+          Collection<ClassInfo> classes = index.getClassesInPackage(pack);
+          if (classes.isEmpty()) throw new IllegalArgumentException("No classes found in package " + pack);
+          return classes.stream();
+        })
         .forEach(classInfo -> {
           ReflectiveClassBuildItem.Builder b = ReflectiveClassBuildItem.builder(classInfo.name().toString());
           reflectiveClass

--- a/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
+++ b/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
@@ -60,6 +60,8 @@ class QuarkusMpxjProcessor {
         .forEach(classInfo -> {
           reflectiveClass
               .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).methods().fields().build());
+          reflectiveClass
+              .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).constructors().fields().build());
         });
   }
 }

--- a/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
+++ b/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
@@ -47,7 +47,7 @@ class QuarkusMpxjProcessor {
   @BuildStep
   void addDependencies(BuildProducer<IndexDependencyBuildItem> indexDependency) {
     logger.info("Producing index dependency build items for mpxj");
-    indexDependency.produce(new IndexDependencyBuildItem("org.mpxj", "mpxj"));
+    indexDependency.produce(new IndexDependencyBuildItem("net.sf.mpxj", "mpxj"));
   }
 
   @BuildStep

--- a/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
+++ b/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
@@ -66,9 +66,7 @@ class QuarkusMpxjProcessor {
         .forEach(classInfo -> {
           ReflectiveClassBuildItem.Builder b = ReflectiveClassBuildItem.builder(classInfo.getClass());
           reflectiveClass
-              .produce(b.methods().fields().build());
-          reflectiveClass
-              .produce(b.constructors().fields().build());
+              .produce(b.methods().fields().constructors().build());
         });
   }
 }

--- a/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
+++ b/deployment/src/main/java/se/yolean/quarkus/mpxj/deployment/QuarkusMpxjProcessor.java
@@ -58,10 +58,11 @@ class QuarkusMpxjProcessor {
     packagesToReflect.stream()
         .flatMap(pack -> index.getClassesInPackage(pack).stream())
         .forEach(classInfo -> {
+          ReflectiveClassBuildItem.Builder b = ReflectiveClassBuildItem.builder(classInfo.name().toString());
           reflectiveClass
-              .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).methods().fields().build());
+              .produce(b.methods().fields().build());
           reflectiveClass
-              .produce(ReflectiveClassBuildItem.builder(classInfo.name().toString()).constructors().fields().build());
+              .produce(b.constructors().fields().build());
         });
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.24.2</quarkus.version>
+    <quarkus.version>3.24.5</quarkus.version>
     <surefire-plugin.version>3.5.3</surefire-plugin.version>
     <project.scm.id>github</project.scm.id>
   </properties>


### PR DESCRIPTION
Tries to fix `java.lang.NoSuchMethodException: org.mpxj.mspdi.schema.Adapter1.<init>()` at Project XML export from native builds.

After 3e317f1f0b51262a17d7e91d42782362e49cccf1 mvn deploy fails. It's possible that 9681fe4a32c7e02c3f4a891eb8c7accf88dc4b90 is a fix but I have no repro in native build tests.